### PR TITLE
[FEAT] Category & UserCategory CRUD 기능 구현

### DIFF
--- a/src/main/java/com/example/onlineexamplatform/common/code/ErrorStatus.java
+++ b/src/main/java/com/example/onlineexamplatform/common/code/ErrorStatus.java
@@ -12,7 +12,12 @@ public enum ErrorStatus implements BaseErrorCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "1001", "고객 정보가 없습니다."),
 	USER_DEACTIVATE(HttpStatus.FORBIDDEN, "1002", "비활성화된 계정입니다."),
 	USER_NOT_MATCH(HttpStatus.UNAUTHORIZED, "1003", "로그인 정보가 일치하지 않습니다."),
-	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "1004", "이미 사용중인 이메일입니다.");
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "1004", "이미 사용중인 이메일입니다."),
+
+	// user-category 에러 코드
+	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "2001", "존재하지 않는 카테고리입니다."),
+	DUPLICATE_USER_CATEGORY(HttpStatus.CONFLICT, "2002", "이미 등록된 응시 권한입니다."),
+	USER_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "2003", "응시 권한이 존재하지 않습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/onlineexamplatform/common/code/SuccessStatus.java
+++ b/src/main/java/com/example/onlineexamplatform/common/code/SuccessStatus.java
@@ -44,7 +44,14 @@ public enum SuccessStatus implements BaseCode {
 
 	// 7000 : 검색 성공 코드
 	SEARCH_SUCCESS(HttpStatus.OK, "7001", "검색에 성공했습니다."),
-	POPULAR_SEARCH_SUCCESS(HttpStatus.OK, "7002", "인기 검색어 호출에 성공했습니다.");
+	POPULAR_SEARCH_SUCCESS(HttpStatus.OK, "7002", "인기 검색어 호출에 성공했습니다."),
+
+	// 9000 : 응시 권한 성공 코드
+	USERCATEGORY_CREATE_SUCCESS(HttpStatus.CREATED, "9001", "응시 권한 생성에 성공했습니다."),
+	USERCATEGORY_GET_SUCCESS(HttpStatus.OK, "9002", "응시 권한 목록 조회에 성공했습니다."),
+	USERCATEGORY_DELETE_SUCCESS(HttpStatus.OK, "9003", "응시 권한 삭제에 성공했습니다.");
+
+
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/example/onlineexamplatform/domain/category/CategoryInitializer.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/category/CategoryInitializer.java
@@ -1,0 +1,28 @@
+package com.example.onlineexamplatform.domain.category;
+
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import com.example.onlineexamplatform.domain.category.entity.Category;
+import com.example.onlineexamplatform.domain.category.entity.CategoryType;
+import com.example.onlineexamplatform.domain.category.repository.CategoryRepository;
+
+import lombok.RequiredArgsConstructor;
+/**
+ * 애플리케이션 실행시 enum에 정의한 값들을
+ * category 테이블에 해당 값이 존재하지 않으면 자동으로 저장함.
+ */
+@Component
+@RequiredArgsConstructor
+public class CategoryInitializer implements CommandLineRunner {
+
+	private final CategoryRepository categoryRepository;
+
+	@Override
+	public void run(String... args) {
+		for (CategoryType type : CategoryType.values()) {
+			categoryRepository.findByCategoryType(type)
+					.orElseGet(() -> categoryRepository.save(new Category(type)));
+		}
+	}
+}

--- a/src/main/java/com/example/onlineexamplatform/domain/category/entity/Category.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/category/entity/Category.java
@@ -1,14 +1,23 @@
 package com.example.onlineexamplatform.domain.category.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Category {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @Enumerated(EnumType.STRING)
-    private CategoryName categoryType;
+    @Column(nullable = false, unique = true)
+    private CategoryType categoryType;
+
+    public Category(CategoryType categoryType) {
+        this.categoryType = categoryType;
+    }
 }

--- a/src/main/java/com/example/onlineexamplatform/domain/category/entity/CategoryName.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/category/entity/CategoryName.java
@@ -1,4 +1,0 @@
-package com.example.onlineexamplatform.domain.category.entity;
-
-public enum CategoryName {
-}

--- a/src/main/java/com/example/onlineexamplatform/domain/category/entity/CategoryType.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/category/entity/CategoryType.java
@@ -1,0 +1,9 @@
+package com.example.onlineexamplatform.domain.category.entity;
+
+public enum CategoryType {
+	MATH,
+	ENGLISH,
+	SCIENCE,
+	HISTORY,
+	TECH
+}

--- a/src/main/java/com/example/onlineexamplatform/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,12 @@
+package com.example.onlineexamplatform.domain.category.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.onlineexamplatform.domain.category.entity.Category;
+import com.example.onlineexamplatform.domain.category.entity.CategoryType;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+	Optional<Category> findByCategoryType(CategoryType categoryType);
+}

--- a/src/main/java/com/example/onlineexamplatform/domain/userCategory/controller/UserCategoryController.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/userCategory/controller/UserCategoryController.java
@@ -1,0 +1,55 @@
+package com.example.onlineexamplatform.domain.userCategory.controller;
+
+import com.example.onlineexamplatform.common.code.SuccessStatus;
+import com.example.onlineexamplatform.common.response.ApiResponse;
+import com.example.onlineexamplatform.domain.user.controller.UserController;
+import com.example.onlineexamplatform.domain.userCategory.dto.UserCategoryRequest;
+import com.example.onlineexamplatform.domain.userCategory.dto.UserCategoryResponse;
+import com.example.onlineexamplatform.domain.userCategory.service.UserCategoryService;
+import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user-category")
+@RequiredArgsConstructor
+
+
+public class UserCategoryController {
+
+	private final UserCategoryService userCategoryService;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<UserCategoryResponse>> create(
+			@RequestBody @Valid UserCategoryRequest request,
+			HttpSession session
+	) {
+		Long userId = (Long) session.getAttribute(UserController.SESSION_USER_KEY);
+		UserCategoryResponse response = userCategoryService.create(userId, request);
+		return ApiResponse.onSuccess(SuccessStatus.USERCATEGORY_CREATE_SUCCESS, response);
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<UserCategoryResponse>>> getByUser(HttpSession session) {
+		Long userId = (Long) session.getAttribute(UserController.SESSION_USER_KEY);
+		List<UserCategoryResponse> responseList = userCategoryService.getByUser(userId);
+		return ApiResponse.onSuccess(SuccessStatus.USERCATEGORY_GET_SUCCESS, responseList);
+	}
+
+	@DeleteMapping("/{categoryId}")
+	public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long categoryId,
+			HttpSession session) {
+		Long userId = (Long) session.getAttribute(UserController.SESSION_USER_KEY);
+		userCategoryService.delete(userId, categoryId);
+		return ApiResponse.onSuccess(SuccessStatus.USERCATEGORY_DELETE_SUCCESS);
+	}
+}

--- a/src/main/java/com/example/onlineexamplatform/domain/userCategory/dto/UserCategoryRequest.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/userCategory/dto/UserCategoryRequest.java
@@ -1,0 +1,8 @@
+package com.example.onlineexamplatform.domain.userCategory.dto;
+
+import com.example.onlineexamplatform.domain.category.entity.CategoryType;
+import jakarta.validation.constraints.NotNull;
+
+public record UserCategoryRequest(
+		@NotNull CategoryType categoryType
+) {}

--- a/src/main/java/com/example/onlineexamplatform/domain/userCategory/dto/UserCategoryResponse.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/userCategory/dto/UserCategoryResponse.java
@@ -1,0 +1,9 @@
+package com.example.onlineexamplatform.domain.userCategory.dto;
+
+import com.example.onlineexamplatform.domain.category.entity.CategoryType;
+
+public record UserCategoryResponse(
+		Long userCategoryId,
+		Long userId,
+		CategoryType categoryType
+) {}

--- a/src/main/java/com/example/onlineexamplatform/domain/userCategory/entity/UserCategory.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/userCategory/entity/UserCategory.java
@@ -1,19 +1,38 @@
 package com.example.onlineexamplatform.domain.userCategory.entity;
 
 import com.example.onlineexamplatform.domain.category.entity.Category;
-import com.example.onlineexamplatform.domain.category.entity.CategoryName;
 import com.example.onlineexamplatform.domain.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
+
+/**
+ * 사용자와 카테고리 간의 관계를 나타내는 엔티티
+ * 사용자가 어떤 시험 카테고리에 응시할 수 있는 권한을 가지고 있는지를 저장
+ * 하나의 사용자(User)는 여러 카테고리(Category)에 응시할 수 있으며,
+ * 하나의 카테고리도 여러 사용자와 매핑될 수 있으므로 다대다(N:N) 관계를
+ * 중간 엔티티(UserCategory)로 표현
+ */
 public class UserCategory {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
-    private Category categoryType;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    public UserCategory(User user, Category category) {
+        this.user = user;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/example/onlineexamplatform/domain/userCategory/repository/UserCategoryRepository.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/userCategory/repository/UserCategoryRepository.java
@@ -1,0 +1,14 @@
+package com.example.onlineexamplatform.domain.userCategory.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.onlineexamplatform.domain.category.entity.Category;
+import com.example.onlineexamplatform.domain.userCategory.entity.UserCategory;
+
+public interface UserCategoryRepository extends JpaRepository<UserCategory, Long> {
+	Optional<UserCategory> findByUserIdAndCategory(Long userId, Category category);
+	List<UserCategory> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/onlineexamplatform/domain/userCategory/service/UserCategoryService.java
+++ b/src/main/java/com/example/onlineexamplatform/domain/userCategory/service/UserCategoryService.java
@@ -1,0 +1,72 @@
+package com.example.onlineexamplatform.domain.userCategory.service;
+
+import com.example.onlineexamplatform.common.code.ErrorStatus;
+import com.example.onlineexamplatform.common.error.ApiException;
+import com.example.onlineexamplatform.domain.category.entity.Category;
+import com.example.onlineexamplatform.domain.category.repository.CategoryRepository;
+import com.example.onlineexamplatform.domain.user.entity.User;
+import com.example.onlineexamplatform.domain.user.repository.UserRepository;
+import com.example.onlineexamplatform.domain.userCategory.dto.UserCategoryRequest;
+import com.example.onlineexamplatform.domain.userCategory.dto.UserCategoryResponse;
+import com.example.onlineexamplatform.domain.userCategory.entity.UserCategory;
+import com.example.onlineexamplatform.domain.userCategory.repository.UserCategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+
+/**
+ * 이 서비스 클래스는 사용자(User)와 카테고리(Category) 간의 관계를 관리합니다.
+ * 특정 사용자가 어떤 시험 카테고리에 응시할 수 있는지를 등록, 조회, 삭제하는 기능을 제공합니다.
+ * 관리자가 특정 사용자의 응시 권한을 생성 및 삭제하여 관리
+ * 사용자가 시험에 응시하기 전 해당 카테고리에 대한 권한이 있는지 확인
+ */
+
+public class UserCategoryService {
+
+	private final UserCategoryRepository userCategoryRepository;
+	private final UserRepository userRepository;
+	private final CategoryRepository categoryRepository;
+
+	@Transactional
+	public UserCategoryResponse create(Long userId, UserCategoryRequest request) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new ApiException(ErrorStatus.USER_NOT_FOUND));
+
+		Category category = categoryRepository.findByCategoryType(request.categoryType())
+				.orElseThrow(() -> new ApiException(ErrorStatus.CATEGORY_NOT_FOUND));
+
+		if (userCategoryRepository.findByUserIdAndCategory(userId, category).isPresent()) {
+			throw new ApiException(ErrorStatus.DUPLICATE_USER_CATEGORY);
+		}
+
+		UserCategory saved = userCategoryRepository.save(new UserCategory(user, category));
+
+		return new UserCategoryResponse(saved.getId(), user.getId(), category.getCategoryType());
+	}
+
+	@Transactional(readOnly = true)
+	public List<UserCategoryResponse> getByUser(Long userId) {
+		return userCategoryRepository.findByUserId(userId).stream()
+				.map(uc -> new UserCategoryResponse(
+						uc.getId(),
+						uc.getUser().getId(),
+						uc.getCategory().getCategoryType()
+				))
+				.toList();
+	}
+
+	@Transactional
+	public void delete(Long userId, Long categoryId) {
+		Category category = categoryRepository.findById(categoryId)
+				.orElseThrow(() -> new ApiException(ErrorStatus.CATEGORY_NOT_FOUND));
+
+		UserCategory userCategory = userCategoryRepository.findByUserIdAndCategory(userId, category)
+				.orElseThrow(() -> new ApiException(ErrorStatus.USER_CATEGORY_NOT_FOUND));
+
+		userCategoryRepository.delete(userCategory);
+	}
+}


### PR DESCRIPTION
작업 목록
- Category Entity 및 CategoryType(Enum) 정의
- CategoryInitializer를 통해 서버 시작 시 Enum 값들을 DB에 자동 저장
- UserCategory CRUD (생성, 조회, 삭제) 구현
- SuccessStatus 응답 정의 및 공통 ApiResponse 포맷 적용

추후 작업 예정
- ErrorStatus 응답 메세지 세분화